### PR TITLE
Add flush in BincodeTransport

### DIFF
--- a/essrpc/src/transports/bincode.rs
+++ b/essrpc/src/transports/bincode.rs
@@ -113,7 +113,9 @@ impl<C: Read + Write> ServerTransport for BincodeTransport<C> {
     }
 
     fn tx_response(&mut self, value: impl Serialize) -> Result<()> {
-        self.serialize(value)
+        let res = self.serialize(value);
+        self.channel.flush();
+        res
     }
 }
 


### PR DESCRIPTION
I tried to setup a server by launching a new `std::process::Command` and communicating over `Stdio`. The functions would get called on the server, but I wouldn't receive a response (unless I use `serve_single_call()`). The culprit was this missing `flush` in `tx_response`.